### PR TITLE
chore: bump cgate and tls fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,14 @@ EXPOSE 20123
 RUN \
     # Download unpack and copy CGate
     cd /tmp && \
-    curl -O https://updates.clipsal.com/ClipsalSoftwareDownload/mainsite/cis/technical/CGate/cgate-2.11.4_3251.zip && \
-    unzip cgate-2.11.4_3251.zip && \
+    curl 'https://download.schneider-electric.com/files?p_Doc_Ref=C-Gate_3_Linux_Package_V3.2.3&p_enDocType=Software+-+Release&p_File_Name=cgate-3.2.3_1760+%281%29.zip' -o cgate-3.zip && \
+    unzip cgate-3.zip && \
     cp -rp cgate /usr/local/bin && \
-    rm cgate-2.11.4_3251.zip && \
+    rm cgate-3.zip && \
     rm -rf cgate
+
+# Remove the old TLS Settings from the JDK version, as per Issue #1
+RUN sed -i '/^jdk.tls.disabledAlgorithms=/s/TLSv1, TLSv1.1, //g' /usr/lib/jvm/java-8-openjdk/jre/lib/security/java.security
 
 # Copy the default c-gate config files so they are available for customisation when the add-on starts.
 COPY rootfs/ /usr/local/bin/cgate/config


### PR DESCRIPTION
#6 Bump C-Gate version to 3.2.3
#5 Remove deprecated TLS versions ftom JDK
